### PR TITLE
Minor fix for path injecting & improve pub points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.1.6+1] Minor bug fix on JsonService parameters (2020-07-26)
+
 ## [0.1.6] Bug fix on JsonService parameters (2020-07-23)
 
 * Some issues were found when passing multiple path parameters to the JsonRequest, so some changes had to be done on the service itself.

--- a/lib/clean_framework.dart
+++ b/lib/clean_framework.dart
@@ -1,3 +1,4 @@
+/// clean_framework
 library clean_framework;
 
 export 'package:clean_framework/src/bloc/bloc.dart';

--- a/lib/clean_framework_defaults.dart
+++ b/lib/clean_framework_defaults.dart
@@ -1,3 +1,4 @@
+/// clean_framework_defaults
 library clean_framework_defaults;
 
 export 'package:clean_framework/src/defaults/always_online_connectivity.dart';

--- a/lib/clean_framework_tests.dart
+++ b/lib/clean_framework_tests.dart
@@ -1,3 +1,4 @@
+/// clean_framework_tests
 library clean_framework_tests;
 
 export 'package:clean_framework/src/tests/json_service_response_handler_mock.dart';

--- a/lib/src/defaults/json_service.dart
+++ b/lib/src/defaults/json_service.dart
@@ -88,7 +88,8 @@ abstract class JsonService<
 
     _resolvedPath = Uri(
       pathSegments: injectedPathSegments,
-      queryParameters: injectedQueryParams,
+      queryParameters:
+          (injectedQueryParams?.isEmpty ?? true) ? null : injectedQueryParams,
     ).toString();
 
     final response = await _restApi.request(

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -3,22 +3,16 @@ import 'package:clean_framework/clean_framework.dart';
 abstract class Logger extends ExternalDependency {
   void setLogLevel(LogLevel level);
 
-  /// Log a message at level [Level.verbose].
   void verbose(dynamic message, [dynamic error, StackTrace stackTrace]);
 
-  /// Log a message at level [Level.debug].
   void debug(dynamic message, [dynamic error, StackTrace stackTrace]);
 
-  /// Log a message at level [Level.info].
   void info(dynamic message, [dynamic error, StackTrace stackTrace]);
 
-  /// Log a message at level [Level.warning].
   void warning(dynamic message, [dynamic error, StackTrace stackTrace]);
 
-  /// Log a message at level [Level.error].
   void error(dynamic message, [dynamic error, StackTrace stackTrace]);
 
-  /// Log a message at level [Level.fatal].
   void fatal(dynamic message, [dynamic error, StackTrace stackTrace]);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: clean_framework
 description: Clean Architecture components library, inspired on the guidelines created by Uncle Bob.
-version: 0.1.6
-homepage: http://acme-software.com
+version: 0.1.6+1
+homepage: https://acme-software.com
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -10,18 +10,18 @@ dependencies:
   flutter:
     sdk: flutter
 
-  equatable: ^1.2.0
+  equatable: ^1.2.3
 
-  provider: ^4.1.2
+  provider: ^4.3.1
 
   either_option: ^1.0.6
 
-  http: ^0.12.0+2
+  http: ^0.12.2
 
-  meta: ^1.2.2
+  meta: ^1.1.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.6.3
+  test: ^1.14.4
   mockito: ^4.1.1

--- a/test/defaults/json_service_test.dart
+++ b/test/defaults/json_service_test.dart
@@ -56,7 +56,7 @@ void main() {
     final service = TestJsonService(
       handler,
       RestMethod.get,
-      'test/{id}?p1={param1}&p2={param2}',
+      'test/pre-{id}.json?p1={param1}&p2={param2}',
       restApiMock,
     );
 
@@ -71,7 +71,7 @@ void main() {
     expect(handler.model, isNotNull);
     expect(
       service.resolvedPath,
-      'test/${requestModel.id}?p1=${requestModel.param1}&p2=${requestModel.param2}',
+      'test/pre-${requestModel.id}.json?p1=${requestModel.param1}&p2=${requestModel.param2}',
     );
     expect(handler.model.field, 123);
     expect(handler.model.optionalField, 'default');


### PR DESCRIPTION
Working: `https:example.com/user/{id}  <- id: 40`  => `https:example.com/user/40`
Not working: `https:example.com/user/pre-{id}-suffix  <- id: 40`  => `https:example.com/user/pre-{id}-suffix` **[Fixed]**

Also, updated package version to **v 0.1.6+1**

Removed comments in logger.dart, as `dartdoc` has issue related to docs inheritance and was affecting pub points.