### PR TITLE
## [0.2.3] ViewModel is Equatable, Pipe has canSendDuplicateData para…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ build/
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+/example/ios/Podfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [0.2.2] Updates on Repository (2020-11-12)
+## [0.2.3] ViewModel is Equatable, Pipe has canSendDuplicateData parameter (2020-10-15)
+
+* After some analysis, we found out view models are always equatable in our implementations, so it made sense to add it to the abstract class.
+* In some specific situations, it is desirable to send the same data over a pipe, so a parameter was added to allow that behavior.
+
+## [0.2.2] Updates on Repository (2020-10-12)
 
 * Repository adds a parameter to delete the existing entity if needed, when create is called.
 

--- a/example/lib/example_feature/bloc/example_bloc.dart
+++ b/example/lib/example_feature/bloc/example_bloc.dart
@@ -18,6 +18,6 @@ class ExampleBloc extends Bloc {
   ExampleBloc({ExampleService exampleService}) {
     _useCase =
         ExampleUseCase((viewModel) => exampleViewModelPipe.send(viewModel));
-    exampleViewModelPipe.onListen(() => _useCase.execute());
+    exampleViewModelPipe.whenListenedDo(() => _useCase.execute());
   }
 }

--- a/example/lib/example_feature/model/example_view_model.dart
+++ b/example/lib/example_feature/model/example_view_model.dart
@@ -6,4 +6,7 @@ class ExampleViewModel extends ViewModel {
 
   ExampleViewModel({this.lastLogin, this.loginCount})
       : assert(lastLogin is DateTime && loginCount != null);
+
+  @override
+  List<Object> get props => [lastLogin, loginCount];
 }

--- a/example/lib/payment/bloc/payment_bloc.dart
+++ b/example/lib/payment/bloc/payment_bloc.dart
@@ -24,7 +24,7 @@ class PaymentBloc extends Bloc {
   PaymentBloc({ExampleService exampleService}) {
     _paymentUseCase =
         PaymentUseCase((viewModel) => paymentViewModelPipe.send(viewModel));
-    paymentViewModelPipe.onListen(() => _paymentUseCase.create());
+    paymentViewModelPipe.whenListenedDo(() => _paymentUseCase.create());
 
     amountPipe.receive.listen(amountInputHandler);
     fromAccountPipe.receive.listen(fromAccountInputHandler);

--- a/example/lib/payment/model/payment_view_model.dart
+++ b/example/lib/payment/model/payment_view_model.dart
@@ -17,4 +17,7 @@ class PaymentViewModel extends ViewModel {
       this.serviceStatus = ServiceStatus.unknown,
       this.dataStatus = DataStatus.unknown})
       : assert(fromAccount != null && toAccount != null && amount != null);
+
+  @override
+  List<Object> get props => [fromAccount, toAccount, amount, serviceStatus, dataStatus];
 }

--- a/example/test/example_feature/bloc/example_bloc_mock.dart
+++ b/example/test/example_feature/bloc/example_bloc_mock.dart
@@ -7,7 +7,7 @@ class ExampleBlocMock extends Fake implements ExampleBloc {
   Pipe<ExampleViewModel> exampleViewModelPipe = Pipe<ExampleViewModel>();
 
   ExampleBlocMock() {
-    exampleViewModelPipe.onListen(() {
+    exampleViewModelPipe.whenListenedDo(() {
       exampleViewModelPipe.send(ExampleViewModel(
           lastLogin: DateTime.parse('2020-01-01'), loginCount: 5));
     });

--- a/lib/clean_framework_tests.dart
+++ b/lib/clean_framework_tests.dart
@@ -3,3 +3,4 @@ library clean_framework_tests;
 export 'package:clean_framework/src/tests/json_service_response_handler_mock.dart';
 export 'package:clean_framework/src/tests/rest_api_mock.dart';
 export 'package:clean_framework/src/tests/test_response_handler_widget.dart';
+export 'package:clean_framework/src/tests/view_model_pipe_tester.dart';

--- a/lib/src/model/view_model.dart
+++ b/lib/src/model/view_model.dart
@@ -1,4 +1,6 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 
 @immutable
-abstract class ViewModel {}
+abstract class ViewModel extends Equatable{}
+

--- a/lib/src/tests/view_model_pipe_tester.dart
+++ b/lib/src/tests/view_model_pipe_tester.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:clean_framework/clean_framework.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class ViewModelPipeTester<V extends ViewModel> {
+  Function _launch;
+  final Pipe<V> _publisher;
+  Completer<ViewModelPipeTester> completer;
+  bool hasInitialViewModelBeenReceived = false;
+  V receivedViewModel;
+  StreamSubscription _pipeSubscription;
+
+  ViewModelPipeTester._(Pipe<V> publisher) : _publisher = publisher {
+    _pipeSubscription = _publisher.receive.listen((output) async {
+      receivedViewModel = output;
+      completer.complete();
+
+      hasInitialViewModelBeenReceived = true;
+    });
+  }
+
+  static ViewModelPipeTester forPipe<V extends ViewModel>(Pipe<V> publisher) {
+    if (publisher.whenListenedDo == null)
+      throw MissingListenedCallbackPipeTesterError();
+    return ViewModelPipeTester._(publisher);
+  }
+
+  ViewModelPipeTester whenBeingListenedTo() {
+    // This empty step exists to make the test code more verbose
+    if (hasInitialViewModelBeenReceived)
+      throw InitialViewModelAlreadySentPipeTesterError();
+    return this;
+  }
+
+  ViewModelPipeTester whenDoing(Function launch) {
+    _launch = launch;
+    return this;
+  }
+
+  Future<void> thenExpectA(V item) async {
+    if (hasInitialViewModelBeenReceived == false) {
+      completer = Completer<ViewModelPipeTester>();
+      await completer.future.timeout(const Duration(seconds: 3),
+          onTimeout: () =>
+          throw NeverReceivedInitialViewModelPipeTesterError());
+    }
+
+    if (_launch != null) {
+      completer = Completer<ViewModelPipeTester>();
+      _launch?.call();
+      await completer.future.timeout(const Duration(seconds: 3),
+          onTimeout: () =>
+          throw NeverReceivedUpdatedViewModelPipeTesterError());
+    }
+
+    expect(item, receivedViewModel);
+    return this;
+  }
+
+  void dispose(){
+    _pipeSubscription.cancel();
+    completer?.complete();
+  }
+}
+
+class NeverReceivedInitialViewModelPipeTesterError extends StateError {
+  NeverReceivedInitialViewModelPipeTesterError()
+      : super('Test failed: view model pipe never received the initial model');
+}
+
+class NeverReceivedUpdatedViewModelPipeTesterError extends StateError {
+  NeverReceivedUpdatedViewModelPipeTesterError()
+      : super('Test failed: view model pipe never received the updated model');
+}
+
+class InitialViewModelAlreadySentPipeTesterError extends StateError {
+  InitialViewModelAlreadySentPipeTesterError()
+      : super('Test failed: view model pipe already sent an initial model');
+}
+
+class NeverReceivedPipeTesterError extends StateError {
+  NeverReceivedPipeTesterError(dynamic item)
+      : super('Test failed: pipe never received a ${item.toString()}');
+}
+
+class MissingListenedCallbackPipeTesterError
+    extends NeverReceivedPipeTesterError {
+  MissingListenedCallbackPipeTesterError()
+      : super(
+      'ViewModelPipeTester can only be used with pipes that implement the method whenListenedDo.');
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clean_framework
 description: Clean Architecture components library, inspired on the guidelines created by Uncle Bob.
-version: 0.2.2
+version: 0.2.3
 homepage: https://acme-software.com
 
 environment:

--- a/test/ui/presenter_widget_test.dart
+++ b/test/ui/presenter_widget_test.dart
@@ -23,24 +23,24 @@ void main() {
 
   testWidgets(
       'Presenter and Screen show default data if service is unreachable',
-      (tester) async {
-    final testWidget = MaterialApp(
-      home: BlocProvider<TestBlocWithService>(
-        create: (_) => TestBlocWithService(),
-        child: TestResponseHandlerWidget<TestBlocWithService>(
-            onError: expectAsync1((errorType) {
-              expect(errorType, PublishedErrorType.general);
-            }),
-            child: TestPresenter<TestBlocWithService>()),
-      ),
-    );
+          (tester) async {
+        final testWidget = MaterialApp(
+          home: BlocProvider<TestBlocWithService>(
+            create: (_) => TestBlocWithService(),
+            child: TestResponseHandlerWidget<TestBlocWithService>(
+                onError: expectAsync1((errorType) {
+                  expect(errorType, PublishedErrorType.general);
+                }),
+                child: TestPresenter<TestBlocWithService>()),
+          ),
+        );
 
-    await tester.pumpWidget(testWidget);
-    await tester.pump(Duration(milliseconds: 200));
+        await tester.pumpWidget(testWidget);
+        await tester.pump(Duration(milliseconds: 200));
 
-    expect(find.byType(TestScreen), findsOneWidget);
-    expect(find.text('foo'), findsNothing);
-  });
+        expect(find.byType(TestScreen), findsOneWidget);
+        expect(find.text('foo'), findsNothing);
+      });
 }
 
 class TestPresenter<B extends TestBloc>
@@ -72,6 +72,9 @@ class TestViewModel extends ViewModel {
   final greeting;
 
   TestViewModel({this.greeting = 'foo'});
+
+  @override
+  List<Object> get props => [greeting];
 }
 
 class TestBloc extends ErrorPublisherBloc {
@@ -83,7 +86,7 @@ class TestBloc extends ErrorPublisherBloc {
   }
 
   TestBloc() {
-    viewModelPipe.onListen(() {
+    viewModelPipe.whenListenedDo(() {
       viewModelPipe.send(TestViewModel());
     });
   }
@@ -110,7 +113,7 @@ class TestBlocWithService extends TestBloc {
     );
     _service = TestService(handler);
 
-    viewModelPipe.onListen(() async {
+    viewModelPipe.whenListenedDo(() async {
       await _service.request();
       viewModelPipe.send(_viewModel);
     });
@@ -121,8 +124,8 @@ class TestBlocWithService extends TestBloc {
   }
 
   TestViewModel get _viewModel => TestViewModel(
-        greeting: _businessModel.greeting,
-      );
+    greeting: _businessModel.greeting,
+  );
 }
 
 class TestBusinessModel extends BusinessModel {
@@ -132,11 +135,11 @@ class TestBusinessModel extends BusinessModel {
 class TestService extends JsonService {
   TestService(handler)
       : super(
-          handler: handler,
-          method: RestMethod.get,
-          path: 'fake',
-          restApi: SimpleRestApi(),
-        );
+    handler: handler,
+    method: RestMethod.get,
+    path: 'fake',
+    restApi: SimpleRestApi(),
+  );
 
   @override
   TestResponseModel parseResponse(Map<String, dynamic> jsonResponse) {


### PR DESCRIPTION
…meter (2020-11-12)

* After some analysis, we found out view models are always equatable in our implementations, so it made sense to add it to the abstract class.
* In some specific situations, it is desirable to send the same data over a pipe, so a parameter was added to allow that behavior.